### PR TITLE
Implemented a function for returning nicer name representations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Supported template loaders:
 - ``django.template.loaders.filesystem.Loader``
 - ``django.template.loaders.cached.Loader``
 
-Contributions and comments are welcome using Github at: 
+Contributions and comments are welcome using Github at:
 http://github.com/TyMaszWeb/django-template-finder
 
 Installation
@@ -59,6 +59,48 @@ Search for all templates under ``menu/``, recursively, in all template loaders:
 
     find_all_templates('menu/*')
 
+Generate nicer, human-friendly names for discovered templates in forms:
+
+::
+
+    from templatefinder import find_all_templates, template_choices
+    from django.forms.widgets import Select
+
+    class MyForm(Form):
+        def __init__(self, *args, **kwargs):
+            super(MyForm, self).__init__(*args, **kwargs)
+            found_templates = find_all_templates('menu/*')
+            choices = template_choices(templates=found_templates, display_names=None)
+            self.fields['myfield'].widget = Select(choices=list(choices))
+
+Providing human-friendly names for discovered templates, overriding the built-in
+name calculation:
+
+::
+
+    from templatefinder import find_all_templates, template_choices
+
+    found_templates = find_all_templates('menu/*')
+    choices = template_choices(templates=found_templates, display_names={
+        'menu/menu.html': 'My super awesome menu',
+    })
+
+Using a project-wide setting for overriding the template display names:
+
+::
+
+    from django.conf import settings
+    # note: this should be in your Django project's settings module, and is
+    # only set here for illustration purposes.
+    settings.TEMPLATEFINDER_DISPLAY_NAMES = {
+        'menu/menu.html': 'Super menu',
+        'menu/another-menu.html': 'Another menu',
+    }
+
+    from templatefinder import find_all_templates, template_choices
+
+    found_templates = find_all_templates('menu/*')
+    choices = template_choices(found_templates)
 
 Bugs & Contribution
 ===================

--- a/templatefinder/tests.py
+++ b/templatefinder/tests.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.utils import unittest
 
-from . import find_all_templates
+from . import find_all_templates, template_choices
 
 
 class TemplateFinderTestMixin(object):
@@ -43,3 +43,67 @@ class FilesystemLoaderTest(TemplateFinderTestMixin, unittest.TestCase):
         settings.TEMPLATE_LOADERS = (
             'django.template.loaders.filesystem.Loader',
         )
+
+
+class DisplayNamesTests(unittest.TestCase):
+    """
+    Various scenarios involving the template_choices utility function.
+    """
+    def setUp(self):
+        settings.TEMPLATE_LOADERS = (
+            'django.template.loaders.app_directories.Loader',
+        )
+        settings.TEMPLATEFINDER_DISPLAY_NAMES = {
+            'menu/menu.html': 'Global menu',
+            'menu/submenu.html': 'Global Sub-menu',
+            'menu/complicated_file-name.20xx.html': 'We keep hyphens!',
+        }
+
+    def test_calculating_fallback_names(self):
+        """
+        Without any setting, the filename of each template in the found
+        template paths should be used to calculate a human-friendly version.
+        """
+        templates = find_all_templates('menu/*')
+        # note: we pass in an empty dictionary, because we can't use
+        # the override_settings() decorator or the settings() context manager
+        # and expect tests to pass in 1.3
+        template_tuple = template_choices(templates=templates,
+                                          display_names={})
+        self.assertEqual(list(template_tuple), [
+            (u'menu/complicated_file-name.20xx.html', u'Complicated file-name 20xx'),
+            (u'menu/menu.html', u'Menu'),
+            (u'menu/submenu.html', u'Submenu')
+        ])
+
+    def test_calculating_usage_provided_names(self):
+        """
+        Given a dictionary of template->title mappings on a per-usage basis,
+        prefer the provided ones over either the fallbacks or the global
+        setting, even if provided.
+        """
+        templates = find_all_templates('menu/*')
+        template_tuple = template_choices(templates=templates,
+                                          display_names={
+                                              'menu/menu.html': 'Main Menu',
+                                              'menu/nonexistant.html': 'Fail',
+                                          })
+        self.assertEqual(list(template_tuple), [
+            (u'menu/complicated_file-name.20xx.html', u'Complicated file-name 20xx'),
+            (u'menu/menu.html', u'Main Menu'),
+            (u'menu/submenu.html', u'Submenu')
+        ])
+
+    def test_calculating_global_provided_names(self):
+        """
+        If no display name mapping is provided, and the global setting is
+        defined, prefer it to the fallback calculated names.
+        """
+        templates = find_all_templates('menu/*')
+        template_tuple = template_choices(templates=templates,
+                                          display_names=None)
+        self.assertEqual(list(template_tuple), [
+            (u'menu/complicated_file-name.20xx.html', u'We keep hyphens!'),
+            (u'menu/menu.html', u'Global menu'),
+            (u'menu/submenu.html', u'Global Sub-menu')
+        ])

--- a/templatefinder/utils.py
+++ b/templatefinder/utils.py
@@ -1,12 +1,14 @@
 import fnmatch
 import logging
 import os
+import re
 
 from django.conf import settings
 from django.utils.importlib import import_module
+from django.utils.text import capfirst
 
 
-__all__ = ('find_all_templates',)
+__all__ = ('find_all_templates', 'template_choices')
 
 
 LOGGER = logging.getLogger('templatefinder')
@@ -53,3 +55,45 @@ def find_all_templates(pattern='*.html'):
         else:
             LOGGER.debug('%s is not supported' % loader_name)
     return sorted(set(templates))
+
+
+to_space_re = re.compile(r'[^a-zA-Z0-9\-]+')
+
+
+def template_choices(templates, display_names=None):
+    """
+    Given an iterable of `templates`, calculate human-friendly display names
+    for each of them, optionally using the `display_names` provided, or a
+    global dictionary (`TEMPLATEFINDER_DISPLAY_NAMES`) stored in the Django
+    project's settings.
+
+    .. note:: As the resulting iterable is a lazy generator, if it needs to be
+              consumed more than once, it should be turned into a `set`, `tuple`
+              or `list`.
+
+    :param list templates: an iterable of template paths, as returned by
+                           `find_all_templates`
+    :param display_names: If given, should be a dictionary where each key
+                          represents a template path in `templates`, and each
+                          value is the display text.
+    :type display_names: dictionary or None
+    :return: an iterable of two-tuples representing value (0) & display text (1)
+    :rtype: generator expression
+    """
+    # allow for global template names, as well as usage-local ones.
+    if display_names is None:
+        display_names = getattr(settings, 'TEMPLATEFINDER_DISPLAY_NAMES', {})
+
+    def fix_display_title(template_path):
+        if template_path in display_names:
+            return display_names[template_path]
+        # take the last part from the template path; works even if there is no /
+        lastpart = template_path.rpartition('/')[-1]
+        # take everything to the left of the rightmost . (the file extension)
+        lastpart_minus_suffix = lastpart.rpartition('.')[0]
+        # convert most non-alphanumeric characters into spaces, with the
+        # exception of hyphens.
+        lastpart_spaces = to_space_re.sub(' ', lastpart_minus_suffix)
+        return capfirst(lastpart_spaces)
+
+    return ((template, fix_display_title(template)) for template in templates)


### PR DESCRIPTION
A user who has to choose a template may not always know, or care, what the template path representation is relative to a given template loader. This patch allows for generating a "human-friendly" name for each *filename* in a template list, optionally providing a dictionary from which to take the names - either on a per-use case, or via a project wide setting - allowing the user to be presented with names which might be more appropriate or meaningful [eg: app/includes/news_2_columns.html may be better represented as "Recent news, two columns"]

See the readme changes for usage examples, and the tests for ... tests.