### PR TITLE
Add support for Django>=1.6 in Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "pypy"
 
 env:
+  - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.5,<1.6"
   - DJANGO="Django>=1.4,<1.5"
   - DJANGO="Django>=1.3,<1.4"


### PR DESCRIPTION
I've run tests locally on Python 3.4, 2.7 and Django 1.6.5, and tests pass, so adding to the Travis build.
