### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/templatefinder/utils.py
+++ b/templatefinder/utils.py
@@ -64,7 +64,7 @@ def find_all_templates(pattern='*.html'):
                            fnmatch.fnmatch(rel_filename, pattern):
                             templates.append(rel_filename)
         else:
-            LOGGER.debug('%s is not supported' % loader_name)
+            LOGGER.debug('{0!s} is not supported'.format(loader_name))
     return sorted(set(templates))
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:TyMaszWeb:django-template-finder?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:TyMaszWeb:django-template-finder?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)