### PR TITLE
Add support for Django 1.8-1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,17 @@ script: 'python setup.py test'
 matrix:
   exclude:
     - python: "2.6"
+      env: DJANGO="Django>=1.10,<1.11"
+    - python: "2.6"
       env: DJANGO="Django>=1.9,<1.10"
     - python: "2.6"
       env: DJANGO="Django>=1.8,<1.9"
     - python: "2.6"
       env: DJANGO="Django>=1.7,<1.8"
+    - python: "3.3"
+      env: DJANGO="Django>=1.10,<1.11"
+    - python: "3.3"
+      env: DJANGO="Django>=1.9,<1.10"
     - python: "3.3"
       env: DJANGO="Django>=1.4,<1.5"
     - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
   - "3.4"
 
 env:
+  - DJANGO="Django>=1.10,<1.11"
+  - DJANGO="Django>=1.9,<1.10"
+  - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.7,<1.8"
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.5,<1.6"
@@ -20,6 +23,10 @@ script: 'python setup.py test'
 
 matrix:
   exclude:
+    - python: "2.6"
+      env: DJANGO="Django>=1.9,<1.10"
+    - python: "2.6"
+      env: DJANGO="Django>=1.8,<1.9"
     - python: "2.6"
       env: DJANGO="Django>=1.7,<1.8"
     - python: "3.3"

--- a/runtests.py
+++ b/runtests.py
@@ -8,6 +8,9 @@ from templatefinder import tests
 
 
 def main():
+    template_dirs = (
+        os.path.join(os.path.dirname(__file__), 'templatefinder', 'test_project', 'templates'),
+    )
     settings.configure(
         DATABASES={
             'default': {
@@ -17,9 +20,16 @@ def main():
         INSTALLED_APPS=(
             'templatefinder.test_project.testapp',
         ),
-        TEMPLATE_DIRS=(
-            os.path.join(os.path.dirname(__file__), 'templatefinder', 'test_project', 'templates'),
-        )
+        TEMPLATE_DIRS=template_dirs,
+        TEMPLATES=[{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': template_dirs,
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                ],
+            },
+        }]
     )
     if hasattr(django, 'setup'):
         django.setup()

--- a/templatefinder/tests.py
+++ b/templatefinder/tests.py
@@ -1,5 +1,8 @@
 from django.conf import settings
-from django.utils import unittest
+try:
+    from django.utils import unittest
+except ImportError:
+    import unittest
 
 from . import find_all_templates, flatten_template_loaders, template_choices
 

--- a/templatefinder/tests.py
+++ b/templatefinder/tests.py
@@ -2,6 +2,7 @@ from django.conf import settings
 try:
     from django.utils import unittest
 except ImportError:
+    # Django removed its unittest vendoring in 1.9
     import unittest
 
 from . import find_all_templates, flatten_template_loaders, template_choices

--- a/templatefinder/utils.py
+++ b/templatefinder/utils.py
@@ -54,16 +54,15 @@ def find_all_templates(pattern='*.html'):
             'django.template.loaders.filesystem.Loader',
         ):
             loader_class = getattr(import_module(module), klass)
-            if getattr(loader_class, '_accepts_engine_in_init', False):
+            try:
+                # Between 1.8 and 1.10, its possible to check
+                # _accepts_engine_in_init to see if it accepts one, but the
+                # normal suite of loaders we likely care about all want one.
                 loader = loader_class(engine)
-            else:
-                try:
-                    loader = loader_class()
-                except TypeError:
-                    # probably Django which is modern enough to require
-                    # engine being passed to the init, but has since removed
-                    # _accepts_engine_in_init
-                    loader = loader_class(engine)
+            except TypeError:
+                # Prior to the template refactor in 1.8, loaders never
+                # accepted an engine.
+                loader = loader_class()
             for directory in loader.get_template_sources(''):
                 # In 1.9, Origin is always set.
                 # https://docs.djangoproject.com/en/1.9/releases/1.9/#template-loaderorigin-and-stringorigin-are-removed

--- a/templatefinder/utils.py
+++ b/templatefinder/utils.py
@@ -54,11 +54,15 @@ def find_all_templates(pattern='*.html'):
                 loader = loader_class(Engine.get_default())
             else:
                 loader = loader_class()
-            for dir in loader.get_template_sources(''):
-                for root, dirnames, filenames in os.walk(dir):
+            for directory in loader.get_template_sources(''):
+                # In 1.9, Origin is always set.
+                # https://docs.djangoproject.com/en/1.9/releases/1.9/#template-loaderorigin-and-stringorigin-are-removed
+                if hasattr(directory, 'loader_name'):
+                    directory = directory.name
+                for root, dirnames, filenames in os.walk(directory):
                     for basename in filenames:
                         filename = os.path.join(root, basename)
-                        rel_filename = filename[len(dir)+1:]
+                        rel_filename = filename[len(directory)+1:]
                         if fnmatch.fnmatch(filename, pattern) or \
                            fnmatch.fnmatch(basename, pattern) or \
                            fnmatch.fnmatch(rel_filename, pattern):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3.4-django1.9, py2.7-django1.9, py3.4-django1.8, py3.3-django1.8, py2.7-django1.8, py3.4-django1.7, py3.3-django1.7, py2.7-django1.7, py3.4-django1.6, py3.3-django1.6, py2.7-django1.6, py2.6-django1.6, py3.3-django1.5, py2.7-django1.5, py2.6-django1.5, py2.7-django1.4, py2.6-django1.4, py2.7-django1.3, py2.6-django1.3
+envlist = py3.4-django1.10, py2.7-django1.10, py3.4-django1.9, py2.7-django1.9, py3.4-django1.8, py3.3-django1.8, py2.7-django1.8, py3.4-django1.7, py3.3-django1.7, py2.7-django1.7, py3.4-django1.6, py3.3-django1.6, py2.7-django1.6, py2.6-django1.6, py3.3-django1.5, py2.7-django1.5, py2.6-django1.5, py2.7-django1.4, py2.6-django1.4, py2.7-django1.3, py2.6-django1.3
 
 [testenv]
 commands = {envpython} setup.py test
@@ -7,6 +7,16 @@ commands = {envpython} setup.py test
 ;[testenv:pypy-django1.5]
 ;basepython = pypy
 ;deps = Django>=1.5,<1.6
+
+; Django 1.10.x
+
+[testenv:py3.4-django1.10]
+basepython = python3.4
+deps = Django>=1.10,<1.11
+
+[testenv:py2.7-django1.10]
+basepython = python2.7
+deps = Django>=1.10,<1.11
 
 ; Django 1.9.x
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3.4-django1.7, py3.3-django1.7, py2.7-django1.7, py3.4-django1.6, py3.3-django1.6, py2.7-django1.6, py2.6-django1.6, py3.3-django1.5, py2.7-django1.5, py2.6-django1.5, py2.7-django1.4, py2.6-django1.4, py2.7-django1.3, py2.6-django1.3
+envlist = py3.4-django1.9, py2.7-django1.9, py3.4-django1.8, py3.3-django1.8, py2.7-django1.8, py3.4-django1.7, py3.3-django1.7, py2.7-django1.7, py3.4-django1.6, py3.3-django1.6, py2.7-django1.6, py2.6-django1.6, py3.3-django1.5, py2.7-django1.5, py2.6-django1.5, py2.7-django1.4, py2.6-django1.4, py2.7-django1.3, py2.6-django1.3
 
 [testenv]
 commands = {envpython} setup.py test
@@ -7,6 +7,30 @@ commands = {envpython} setup.py test
 ;[testenv:pypy-django1.5]
 ;basepython = pypy
 ;deps = Django>=1.5,<1.6
+
+; Django 1.9.x
+
+[testenv:py3.4-django1.9]
+basepython = python3.4
+deps = Django>=1.9,<1.10
+
+[testenv:py2.7-django1.9]
+basepython = python2.7
+deps = Django>=1.9,<1.10
+
+; Django 1.8.x
+
+[testenv:py3.4-django1.8]
+basepython = python3.4
+deps = Django>=1.8,<1.9
+
+[testenv:py3.3-django1.8]
+basepython = python3.3
+deps = Django>=1.8,<1.9
+
+[testenv:py2.7-django1.8]
+basepython = python2.7
+deps = Django>=1.8,<1.9
 
 ; Django 1.7.x
 


### PR DESCRIPTION
- In Django 1.9, get_template_sources starts returning Origin objects.
- _accepts_engine_in_init was a transitioning attribute, and now loaders always require an Engine
- settings.TEMPLATE_LOADERS stops being used, being superceded by the TEMPLATES setting

The changes as given represent the minimum necessary to get a travis build working (see [here](https://travis-ci.org/kezabelle/django-template-finder/builds/175692002)) & also working in my local copy.